### PR TITLE
fix: wrong region passed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -103,7 +103,7 @@ function set_ecr_repo_policy() {
   if [ "${1}" = true ]; then
     echo "== START SET REPO POLICY"
     if [ -f "${INPUT_REPO_POLICY_FILE}" ]; then
-      aws ecr set-repository-policy --repository-name $INPUT_REPO --policy-text file://"${INPUT_REPO_POLICY_FILE}"
+      aws ecr set-repository-policy --region $AWS_DEFAULT_REGION --repository-name $INPUT_REPO --policy-text file://"${INPUT_REPO_POLICY_FILE}"
       echo "== FINISHED SET REPO POLICY"
     else
       echo "== REPO POLICY FILE (${INPUT_REPO_POLICY_FILE}) DOESN'T EXIST. SKIPPING.."
@@ -115,7 +115,7 @@ function put_image_scanning_configuration() {
   if [ "${1}" = true ]; then
       echo "== START SET IMAGE SCANNING CONFIGURATION"
     if [ "${INPUT_IMAGE_SCANNING_CONFIGURATION}" = true ]; then
-      aws ecr put-image-scanning-configuration --repository-name $INPUT_REPO --image-scanning-configuration scanOnPush=${INPUT_IMAGE_SCANNING_CONFIGURATION}
+      aws ecr put-image-scanning-configuration --region $AWS_DEFAULT_REGION --repository-name $INPUT_REPO --image-scanning-configuration scanOnPush=${INPUT_IMAGE_SCANNING_CONFIGURATION}
       echo "== FINISHED SET IMAGE SCANNING CONFIGURATION"
     fi
   fi


### PR DESCRIPTION
## Issue
Some 'aws' commands have region passed via the `AWS_DEFAULT_REGION` flag. This flag is overridable via the `AWS_REGION` flag which has a higher priority. If this variable is set in your environment variables the commands use this environment variable which may not be equal to `AWS_DEFAULT_REGION`, commands will fail in such a case. 
## Fix
We can instead pass the region as explicit flags which will block it from being overridden.
## Notes
A new release for github actions will be needed. Create `v4.1.1` as this is a backwards compatible patch fix.